### PR TITLE
prometheus: drop `monitor` label from alerts

### DIFF
--- a/prometheus/templates/prometheus.yml.j2
+++ b/prometheus/templates/prometheus.yml.j2
@@ -15,6 +15,9 @@ rule_files:
 {% if prometheus__alertmanagers %}
 
 alerting:
+  alert_relabel_configs:
+    - action: labeldrop
+      regex: monitor
   alertmanagers:
     - static_configs:
       - targets:

--- a/prometheus/vars/main.yaml
+++ b/prometheus/vars/main.yaml
@@ -32,6 +32,6 @@ __all_scrape_configs: |
     ([__prom_scrape_config] if prometheus__monitored_prometheus else []) +
     ([__federated_scrape_config] if prometheus__federated_prometheus else []) +
     ([__node_scrape_config] if prometheus__monitored_nodes else []) +
-    ([__alertmanager_scrape_config] if prometheus__monitored_alertmanager else []) +
+    ([__alertmanager_scrape_config] if prometheus__alertmanagers else []) +
     (prometheus__scrape_configs or [])
   }}


### PR DESCRIPTION
This was a long-standing bug: the `monitor` label is added to all metrics to
allow tracking which prometheus instance scraped a metric in a federated/HA
set-up, but then the AlertManager cannot de-duplicate alerts coming from
different prometheus instances as the values are different.

This change drops the label before the alerts are sent to the AlertManager.