### PR TITLE
Add prometheus_blackbox_exporter role

### DIFF
--- a/prometheus_blackbox_exporter/defaults/main.yaml
+++ b/prometheus_blackbox_exporter/defaults/main.yaml
@@ -1,0 +1,10 @@
+# vim:ts=2:sw=2:et:ai:sts=2
+---
+
+blackbox_exporter__listen_addr: ''
+blackbox_exporter__listen_port: 9115
+blackbox_exporter__modules: {}
+blackbox_exporter__extra_args:
+blackbox_exporter__config_file: /etc/prometheus/blackbox.yml
+blackbox_exporter__install_ferm_svc: false
+blackbox_exporter__allow_from:

--- a/prometheus_blackbox_exporter/handlers/main.yaml
+++ b/prometheus_blackbox_exporter/handlers/main.yaml
@@ -1,16 +1,16 @@
 # vim:ts=2:sw=2:et:ai:sts=2
 ---
-- name: _blackbox_exporter__restart_blackbox_exporter
+- name: _tina_restart_blackbox_exporter
   ansible.builtin.service:
     name: prometheus-blackbox-exporter
     state: restarted
 
-- name: _blackbox_exporter__reload_blackbox_exporter
+- name: _tina_reload_blackbox_exporter
   ansible.builtin.service:
     name: prometheus-blackbox-exporter
     state: reloaded
 
-- name: _blackbox_exporter__reload_ferm
+- name: _tina_reload_ferm
   ansible.builtin.service:
     name: ferm
     state: reloaded

--- a/prometheus_blackbox_exporter/handlers/main.yaml
+++ b/prometheus_blackbox_exporter/handlers/main.yaml
@@ -1,0 +1,16 @@
+# vim:ts=2:sw=2:et:ai:sts=2
+---
+- name: _blackbox_exporter__restart_blackbox_exporter
+  ansible.builtin.service:
+    name: prometheus-blackbox-exporter
+    state: restarted
+
+- name: _blackbox_exporter__reload_blackbox_exporter
+  ansible.builtin.service:
+    name: prometheus-blackbox-exporter
+    state: reloaded
+
+- name: _blackbox_exporter__reload_ferm
+  ansible.builtin.service:
+    name: ferm
+    state: reloaded

--- a/prometheus_blackbox_exporter/tasks/main.yaml
+++ b/prometheus_blackbox_exporter/tasks/main.yaml
@@ -12,7 +12,7 @@
     owner: root
     group: root
     mode: '0644'
-  notify: _blackbox_exporter__reload_blackbox_exporter
+  notify: _tina_reload_blackbox_exporter
 
 - name: Configure service
   ansible.builtin.template:
@@ -21,7 +21,7 @@
     owner: root
     group: root
     mode: '0644'
-  notify: _blackbox_exporter__restart_blackbox_exporter
+  notify: _tina_restart_blackbox_exporter
 
 - name: Start and enable service
   ansible.builtin.service:
@@ -36,5 +36,5 @@
     owner: root
     group: adm
     mode: '0644'
-  notify: _blackbox_exporter__reload_ferm
+  notify: _tina_reload_ferm
   when: blackbox_exporter__install_ferm_svc | bool

--- a/prometheus_blackbox_exporter/tasks/main.yaml
+++ b/prometheus_blackbox_exporter/tasks/main.yaml
@@ -1,0 +1,40 @@
+# vim:ts=2:sw=2:et:ai:sts=2
+---
+- name: Install package
+  ansible.builtin.package:
+    name: prometheus-blackbox-exporter
+    state: present
+
+- name: Configure probes
+  ansible.builtin.template:
+    src: blackbox.yml.j2
+    dest: '{{ blackbox_exporter__config_file }}'
+    owner: root
+    group: root
+    mode: '0644'
+  notify: _blackbox_exporter__reload_blackbox_exporter
+
+- name: Configure service
+  ansible.builtin.template:
+    src: default.j2
+    dest: /etc/default/prometheus-blackbox-exporter
+    owner: root
+    group: root
+    mode: '0644'
+  notify: _blackbox_exporter__restart_blackbox_exporter
+
+- name: Start and enable service
+  ansible.builtin.service:
+    name: prometheus-blackbox-exporter
+    state: started
+    enabled: true
+
+- name: Install ferm configuration
+  ansible.builtin.template:
+    src: ferm.conf.j2
+    dest: /etc/ferm/ferm.d/prometheus-blackbox-exporter.conf
+    owner: root
+    group: adm
+    mode: '0644'
+  notify: _blackbox_exporter__reload_ferm
+  when: blackbox_exporter__install_ferm_svc | bool

--- a/prometheus_blackbox_exporter/templates/blackbox.yml.j2
+++ b/prometheus_blackbox_exporter/templates/blackbox.yml.j2
@@ -1,0 +1,5 @@
+# {{ ansible_managed }}
+---
+{% if blackbox_exporter__modules %}
+{{ dict(modules=blackbox_exporter__modules) | to_yaml(sort_keys=false) }}
+{% endif %}

--- a/prometheus_blackbox_exporter/templates/default.j2
+++ b/prometheus_blackbox_exporter/templates/default.j2
@@ -1,0 +1,8 @@
+# {{ ansible_managed }}
+
+ARGS=" \
+      --config.file={{ blackbox_exporter__config_file }} \
+      --web.listen-address={{
+          blackbox_exporter__listen_addr ~ ':' ~ blackbox_exporter__listen_port
+          }} \
+      {{ blackbox_exporter__extra_args }}"

--- a/prometheus_blackbox_exporter/templates/ferm.conf.j2
+++ b/prometheus_blackbox_exporter/templates/ferm.conf.j2
@@ -1,0 +1,10 @@
+# {{ ansible_managed }}
+domain (ip ip6) table filter chain INPUT {
+    proto tcp
+{% if blackbox_exporter__allow_from %}
+{% set saddr = blackbox_exporter__allow_from %}
+{% set saddr = saddr if saddr is string else saddr | join(' ') %}
+    saddr @ipfilter(({{ saddr}}))
+{% endif %}
+    dport {{ blackbox_exporter__listen_port }} ACCEPT;
+}


### PR DESCRIPTION
```
❯ ansible-lint prometheus_blackbox_exporter
Passed: 0 failure(s), 0 warning(s) on 7 files.
Profile 'production' was required, and it passed.
```