### PR TITLE
Pass ansible-lint w/ moderate profile and some skipped rules

### DIFF
--- a/.config/ansible-lint-ignore.txt
+++ b/.config/ansible-lint-ignore.txt
@@ -1,0 +1,4 @@
+# These are raised when running `ansible-lint *`.
+base-setup 			role-name
+simple-bind			role-name
+prometheus-node-exporter	role-name

--- a/.config/ansible-lint.yaml
+++ b/.config/ansible-lint.yaml
@@ -4,5 +4,4 @@ profile: moderate
 skip_list:
   - jinja[spacing]  # Noise in multi-line template expr.
   - name[casing]    # Grandfathered (for now).
-  - name[missing]   # TODO: fix.
   - name[template]  # "Jinja templates should only be at the end of 'name'"

--- a/.config/ansible-lint.yaml
+++ b/.config/ansible-lint.yaml
@@ -1,0 +1,8 @@
+# vim:ts=2:sw=2:et:ai:sts=2
+---
+profile: moderate
+skip_list:
+  - jinja[spacing]  # Noise in multi-line template expr.
+  - name[casing]    # Grandfathered (for now).
+  - name[missing]   # TODO: fix.
+  - name[template]  # "Jinja templates should only be at the end of 'name'"

--- a/.github/workflows/ansible-lint.yaml
+++ b/.github/workflows/ansible-lint.yaml
@@ -1,0 +1,24 @@
+---
+name: ansible-lint
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - force_ci/ansible-lint/**  # For development/debugging of the workflow.
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  lint:
+    name: Ansible lint
+    runs-on: ubuntu-latest
+    steps:
+      - id: checkout
+        uses: actions/checkout@v4
+
+      - name: Run ansible-lint
+        uses: ansible/ansible-lint@v24

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -21,4 +21,3 @@ rules:
       - ^[0-9:]+$  # IPv6 addresses containing only numbers 0-9 are misparsed
     extra-allowed:
       - ^\^   # regular expressions
-      - ^=}$  # variable_end_string

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -14,3 +14,11 @@ rules:
   octal-values:
     forbid-implicit-octal: true  # Required by ansible-lint
     forbid-explicit-octal: true  # Required by ansible-lint
+  quoted-strings:
+    quote-type: single
+    required: only-when-needed
+    extra-required:
+      - ^[0-9:]+$  # IPv6 addresses containing only numbers 0-9 are misparsed
+    extra-allowed:
+      - ^\^   # regular expressions
+      - ^=}$  # variable_end_string

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -20,4 +20,4 @@ rules:
     extra-required:
       - ^[0-9:]+$  # IPv6 addresses containing only numbers 0-9 are misparsed
     extra-allowed:
-      - ^\^   # regular expressions
+      - ^\^   # regular expression

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,16 @@
+# vim:ts=2:sw=2:et:ai:sts=2
+---
+extends: default
+rules:
+  comments:
+    min-spaces-from-content: 1  # Required by ansible-lint
+  comments-indentation: false  # Required by ansible-lint
+  document-start: disable
+  line-length:
+    max: 80
+  braces:
+    min-spaces-inside: 0  # Required by ansible-lint
+    max-spaces-inside: 1  # Required by ansible-lint
+  octal-values:
+    forbid-implicit-octal: true  # Required by ansible-lint
+    forbid-explicit-octal: true  # Required by ansible-lint

--- a/apache2/defaults/main.yaml
+++ b/apache2/defaults/main.yaml
@@ -12,7 +12,7 @@ apache2__sites_available_dir: '{{ apache2__serverroot }}/sites-available'
 apache2__sites_enabled_dir: '{{ apache2__serverroot }}/sites-enabled'
 
 # Permissions for configuration files.
-apache2__conffile_mode: 0644
+apache2__conffile_mode: '0644'
 apache2__conffile_owner: root
 apache2__conffile_group: root
 
@@ -62,7 +62,7 @@ apache2__ferm_ports: ~
 apache2__logdirs:
   - /var/log/apache2
 # Permissions for log directories.
-apache2__logdirs_mode: 0750
+apache2__logdirs_mode: '0750'
 apache2__logdirs_owner: root
 apache2__logdirs_group: adm
 

--- a/apache2/defaults/main.yaml
+++ b/apache2/defaults/main.yaml
@@ -49,7 +49,7 @@ apache2__sites: {}
 
 # FIXME(Tina): Not yet implemented.
 # If true, remove available sites not listed in `apache2__sites`.
-#apache2__manage_sites: false
+# apache2__manage_sites: false
 
 # If true, install ferm configuration file.
 apache2__install_ferm_svc: false

--- a/apache2/tasks/main.yaml
+++ b/apache2/tasks/main.yaml
@@ -20,7 +20,7 @@
     dest: /etc/apache2/ports.conf
     owner: root
     group: root
-    mode: 0644
+    mode: '0644'
   notify: apache2__restart_apache2
 
 - name: start and enable service
@@ -35,7 +35,7 @@
     dest: /etc/ferm/ferm.d/apache2.conf
     owner: root
     group: adm
-    mode: 0644
+    mode: '0644'
   notify: apache2__reload_ferm
   when: _a2_install_ferm_svc | bool
 
@@ -45,7 +45,7 @@
     dest: /etc/logrotate.d/apache2
     owner: root
     group: root
-    mode: 0644
+    mode: '0644'
   notify: apache2__reload_ferm
   when: _a2_install_ferm_svc | bool
 

--- a/apache2/tasks/main.yaml
+++ b/apache2/tasks/main.yaml
@@ -27,7 +27,7 @@
   service:
     name: apache2
     state: started
-    enabled: yes
+    enabled: true
 
 - name: install ferm configuration
   template:

--- a/apache2/vars/main.yaml
+++ b/apache2/vars/main.yaml
@@ -134,8 +134,8 @@ _a2_logrotate_conf:
   globs: |-
     {{
       [__a2_logrotate_conf_globs]
-      if (__a2_logrotate_conf_globs is not iterable
-          or __a2_logrotate_conf_globs is string)
+      if (__a2_logrotate_conf_globs is not iterable or
+          __a2_logrotate_conf_globs is string)
       else __a2_logrotate_conf_globs
     }}
   interval: |-

--- a/apache2/vars/main.yaml
+++ b/apache2/vars/main.yaml
@@ -134,7 +134,8 @@ _a2_logrotate_conf:
   globs: |-
     {{
       [__a2_logrotate_conf_globs]
-      if __a2_logrotate_conf_globs is not iterable or __a2_logrotate_conf_globs is string
+      if (__a2_logrotate_conf_globs is not iterable
+          or __a2_logrotate_conf_globs is string)
       else __a2_logrotate_conf_globs
     }}
   interval: |-

--- a/apt/tasks/main.yaml
+++ b/apt/tasks/main.yaml
@@ -37,7 +37,7 @@
     content: '{{ item.value | b64decode }}'
     owner: root
     group: root
-    mode: 0644
+    mode: '0644'
   loop: '{{ apt__trusted_keys | d({}) | dict2items }}'
   when: item.value
   register: _apt_trusted_keys
@@ -56,7 +56,7 @@
     content: '{{ item.value }}'
     owner: root
     group: root
-    mode: 0644
+    mode: '0644'
   loop: '{{ apt__custom_preferences | d({}) | dict2items }}'
   when: item.value
   register: _apt_custom_preferences

--- a/apt/tasks/main.yaml
+++ b/apt/tasks/main.yaml
@@ -76,7 +76,7 @@
 
 - name: update package lists
   apt:
-    update_cache: yes
+    update_cache: true
     cache_valid_time: '{{
       0 if (
         apt__force_run_update or _apt_sources.changed or
@@ -96,7 +96,7 @@
 
 - name: remove unneeded packages
   apt:
-    autoremove: yes
+    autoremove: true
     purge: '{{ apt__purge_removed }}'
   when: apt__run_autoremove
 
@@ -108,7 +108,7 @@
 - name: enable services
   service:
     name: '{{ item }}'
-    enabled: yes
+    enabled: true
   loop: '{{ apt__services_to_enable or [] }}'
 
 - name: start services

--- a/apt/tasks/main.yaml
+++ b/apt/tasks/main.yaml
@@ -18,14 +18,14 @@
 - name: configure custom APT sources
   template:
     src: sources.list.d.j2
-    dest: '/etc/apt/sources.list.d/{{ item.key }}.list'
+    dest: /etc/apt/sources.list.d/{{ item.key }}.list
   loop: '{{ apt__custom_sources | d({}) | dict2items }}'
   when: item.value
   register: _apt_custom_sources
 
 - name: delete custom APT sources
   file:
-    path: '/etc/apt/sources.list.d/{{ item.key }}.list'
+    path: /etc/apt/sources.list.d/{{ item.key }}.list
     state: absent
   loop: '{{ apt__custom_sources | d({}) | dict2items }}'
   when: not item.value
@@ -33,7 +33,7 @@
 
 - name: configure custom APT trusted keys
   copy:
-    dest: '/etc/apt/trusted.gpg.d/{{ item.key }}.gpg'
+    dest: /etc/apt/trusted.gpg.d/{{ item.key }}.gpg
     content: '{{ item.value | b64decode }}'
     owner: root
     group: root
@@ -44,7 +44,7 @@
 
 - name: delete custom APT trusted keys
   file:
-    path: '/etc/apt/trusted.gpg.d/{{ item.key }}.gpg'
+    path: /etc/apt/trusted.gpg.d/{{ item.key }}.gpg
     state: absent
   loop: '{{ apt__trusted_keys | d({}) | dict2items }}'
   when: not item.value
@@ -52,7 +52,7 @@
 
 - name: configure custom APT preferences
   copy:
-    dest: '/etc/apt/preferences.d/{{ item.key }}'
+    dest: /etc/apt/preferences.d/{{ item.key }}
     content: '{{ item.value }}'
     owner: root
     group: root
@@ -63,7 +63,7 @@
 
 - name: delete custom APT preferences
   file:
-    path: '/etc/apt/preferences.d/{{ item.key }}'
+    path: /etc/apt/preferences.d/{{ item.key }}
     state: absent
   loop: '{{ apt__custom_preferences | d({}) | dict2items }}'
   when: not item.value

--- a/base-setup/defaults/main.yaml
+++ b/base-setup/defaults/main.yaml
@@ -1,22 +1,22 @@
 # vim:ts=2:sw=2:et:ai:sts=2
 ---
-base_setup__disable_cloud_init: False
-base_setup__disable_resolved: False
+base_setup__disable_cloud_init: false
+base_setup__disable_resolved: false
 base_setup__set_hostname: ~
 
 base_setup__pkg_install: []
 base_setup__svc_enable_start: []
 
-base_setup__setup_sudo: True
+base_setup__setup_sudo: true
 
-base_setup__setup_postfix: True
+base_setup__setup_postfix: true
 base_setup__mail_relay: ~
 
-base_setup__setup_locales: True
+base_setup__setup_locales: true
 base_setup__default_locale: en_US.UTF-8
 base_setup__locales_to_be_generated:
   - en_US.UTF-8 UTF-8
 
 # Set to null to disable managing the sshd configuration.
-base_setup__sshd_password_auth_allowed: False
-base_setup__sshd_root_login_allowed: False
+base_setup__sshd_password_auth_allowed: false
+base_setup__sshd_root_login_allowed: false

--- a/base-setup/tasks/main.yaml
+++ b/base-setup/tasks/main.yaml
@@ -70,20 +70,20 @@
 
 - name: 'set-up sudoers: sudo group'
   lineinfile:
-      dest: /etc/sudoers
-      state: present
-      regexp: '^%sudo\s'
-      line: '%sudo ALL=(ALL) ALL'
-      validate: 'visudo -cf %s'
+    dest: /etc/sudoers
+    state: present
+    regexp: '^%sudo\s'
+    line: '%sudo ALL=(ALL) ALL'
+    validate: 'visudo -cf %s'
   when: base_setup__setup_sudo
 
 - name: 'set-up sudoers: sudo-nopw group'
   lineinfile:
-      dest: /etc/sudoers
-      state: present
-      regexp: '^%sudo-nopw\s'
-      line: '%sudo-nopw ALL=(ALL) NOPASSWD: ALL'
-      validate: 'visudo -cf %s'
+    dest: /etc/sudoers
+    state: present
+    regexp: '^%sudo-nopw\s'
+    line: '%sudo-nopw ALL=(ALL) NOPASSWD: ALL'
+    validate: 'visudo -cf %s'
   when: base_setup__setup_sudo
 
 - name: set default locale
@@ -125,27 +125,27 @@
 
 - name: 'sshd: disable password authentication'
   lineinfile:
-      dest: /etc/ssh/sshd_config
-      state: present
-      regexp: '^PasswordAuthentication\s'
-      insertafter: '^#\s*PasswordAuthentication\s'
-      line: |-
-        PasswordAuthentication {{
-          'yes' if base_setup__sshd_password_auth_allowed else 'no'
-        }}
+    dest: /etc/ssh/sshd_config
+    state: present
+    regexp: '^PasswordAuthentication\s'
+    insertafter: '^#\s*PasswordAuthentication\s'
+    line: |-
+      PasswordAuthentication {{
+        'yes' if base_setup__sshd_password_auth_allowed else 'no'
+      }}
   when: base_setup__sshd_password_auth_allowed in (True, False)
   notify: base_setup__reload_sshd
 
 - name: 'sshd: disable root login'
   lineinfile:
-      dest: /etc/ssh/sshd_config
-      state: present
-      regexp: '^PermitRootLogin\s'
-      insertafter: '^#\s*PermitRootLogin\s'
-      line: |-
-        PermitRootLogin {{
-          'prohibit-password' if base_setup__sshd_root_login_allowed else 'no'
-        }}
+    dest: /etc/ssh/sshd_config
+    state: present
+    regexp: '^PermitRootLogin\s'
+    insertafter: '^#\s*PermitRootLogin\s'
+    line: |-
+      PermitRootLogin {{
+        'prohibit-password' if base_setup__sshd_root_login_allowed else 'no'
+      }}
   when: base_setup__sshd_root_login_allowed in (True, False)
   notify: base_setup__reload_sshd
 

--- a/base-setup/tasks/main.yaml
+++ b/base-setup/tasks/main.yaml
@@ -61,7 +61,7 @@
 - name: set mail relay
   lineinfile:
     dest: /etc/postfix/main.cf
-    line: 'relayhost = {{ base_setup__mail_relay }}'
+    line: relayhost = {{ base_setup__mail_relay }}
     regexp: '^relayhost\s*='
     insertafter: '^\s*#relayhost'
     state: present
@@ -74,7 +74,7 @@
     state: present
     regexp: '^%sudo\s'
     line: '%sudo ALL=(ALL) ALL'
-    validate: 'visudo -cf %s'
+    validate: visudo -cf %s
   when: base_setup__setup_sudo
 
 - name: 'set-up sudoers: sudo-nopw group'
@@ -83,7 +83,7 @@
     state: present
     regexp: '^%sudo-nopw\s'
     line: '%sudo-nopw ALL=(ALL) NOPASSWD: ALL'
-    validate: 'visudo -cf %s'
+    validate: visudo -cf %s
   when: base_setup__setup_sudo
 
 - name: set default locale
@@ -112,12 +112,12 @@
 - name: 'sshd: verify host keys presence'
   find:
     paths: /etc/ssh
-    patterns: 'ssh_host_*'
+    patterns: ssh_host_*
   register: _ssh_host_keys
 
 - name: 'sshd: regenerate host keys'
   command:
-    cmd: 'dpkg-reconfigure openssh-server'
+    cmd: dpkg-reconfigure openssh-server
   environment:
     DEBIAN_FRONTEND: noninteractive
   when: not _ssh_host_keys.files

--- a/fail2ban/tasks/main.yaml
+++ b/fail2ban/tasks/main.yaml
@@ -21,7 +21,7 @@
     dest: /etc/fail2ban/jail.local
     owner: root
     group: root
-    mode: 0644
+    mode: '0644'
   notify: fail2ban__restart_fail2ban
 
 - name: place path overrides configuration file
@@ -30,7 +30,7 @@
     dest: /etc/fail2ban/paths-overrides.local
     owner: root
     group: root
-    mode: 0644
+    mode: '0644'
   notify: fail2ban__restart_fail2ban
 
 - name: place iptables action configuration file
@@ -39,7 +39,7 @@
     dest: /etc/fail2ban/action.d/iptables.local
     owner: root
     group: root
-    mode: 0644
+    mode: '0644'
   notify: fail2ban__restart_fail2ban
 
 - name: place ferm config file
@@ -48,6 +48,6 @@
     dest: /etc/ferm/ferm.d/fail2ban.conf
     owner: root
     group: adm
-    mode: 0644
+    mode: '0644'
   notify: fail2ban__reload_ferm
   when: fail2ban__install_ferm_svc | bool

--- a/fail2ban/tasks/main.yaml
+++ b/fail2ban/tasks/main.yaml
@@ -13,7 +13,7 @@
   service:
     name: fail2ban
     state: started
-    enabled: yes
+    enabled: true
 
 - name: place jail configuration file
   template:

--- a/ferm/defaults/main.yaml
+++ b/ferm/defaults/main.yaml
@@ -1,7 +1,7 @@
 # vim:ts=2:sw=2:et:ai:sts=2
 ---
 # Allow incoming SSH connections from all hosts.
-ferm__open_ssh: True
+ferm__open_ssh: true
 
 # Simple service configuration.
 # ferm__services:

--- a/ferm/tasks/main.yaml
+++ b/ferm/tasks/main.yaml
@@ -30,9 +30,9 @@
 - name: disable caching
   lineinfile:
     dest: /etc/default/ferm
-    line: 'CACHE=no'
+    line: CACHE=no
     regexp: '^CACHE[ =]'
-    state: 'present'
+    state: present
   notify: ferm__reload_ferm
 
 - name: create ferm.d directory

--- a/ferm/tasks/main.yaml
+++ b/ferm/tasks/main.yaml
@@ -41,7 +41,7 @@
     state: directory
     owner: root
     group: adm
-    mode: 02750
+    mode: '02750'
 
 - name: place main config file
   template:
@@ -49,7 +49,7 @@
     dest: /etc/ferm/ferm.conf
     owner: root
     group: adm
-    mode: 0644
+    mode: '0644'
   notify: ferm__reload_ferm
 
 - name: place service config files
@@ -58,7 +58,7 @@
     dest: /etc/ferm/ferm.d/svc-{{ item.key }}.conf
     owner: root
     group: adm
-    mode: 0644
+    mode: '0644'
   notify: ferm__reload_ferm
   with_dict: '{{ ferm__services }}'
 
@@ -84,7 +84,7 @@
     dest: /etc/ferm/ferm.d/custom-{{ item.key }}.conf
     owner: root
     group: adm
-    mode: 0644
+    mode: '0644'
   notify: ferm__reload_ferm
   with_dict: '{{ ferm__custom_configs }}'
 
@@ -109,7 +109,7 @@
     dest: /etc/ferm/ferm.d/00-blacklist.conf
     owner: root
     group: adm
-    mode: 0644
+    mode: '0644'
     content: |
       domain (ip ip6) table filter chain blacklist
           saddr @ipfilter(({{ saddr }}))

--- a/ferm/tasks/main.yaml
+++ b/ferm/tasks/main.yaml
@@ -6,7 +6,7 @@
     question: ferm/enable
     value: 'yes'
     vtype: boolean
-  changed_when: False
+  changed_when: false
 
 - name: install package
   apt:
@@ -17,15 +17,15 @@
   shell: >-
     /usr/sbin/ferm --version | sed -n 's/^ferm \([0-9].*\)/\1/p'
   register: ferm__version_check
-  changed_when: False
+  changed_when: false
   # Run normally even in check mode.
-  check_mode: no
+  check_mode: false
 
 - name: find installed version
   set_fact:
     ferm__version: '{{ ferm__version_check.stdout | d("0") }}'
   # Run normally even in check mode.
-  check_mode: no
+  check_mode: false
 
 - name: disable caching
   lineinfile:
@@ -67,8 +67,8 @@
     ls /etc/ferm/ferm.d/ |
     sed -n 's/^svc-\(.*\)\.conf$/\1/p'
   register: ferm__config_files
-  changed_when: False
-  check_mode: no
+  changed_when: false
+  check_mode: false
 
 - name: remove obsolete service config files
   file:
@@ -93,8 +93,8 @@
     ls /etc/ferm/ferm.d/ |
     sed -n 's/^custom-\(.*\)\.conf$/\1/p'
   register: ferm__config_files
-  changed_when: False
-  check_mode: no
+  changed_when: false
+  check_mode: false
 
 - name: remove obsolete custom config files
   file:
@@ -125,4 +125,4 @@
   service:
     name: ferm
     state: started
-    enabled: yes
+    enabled: true

--- a/mtail/tasks/main.yaml
+++ b/mtail/tasks/main.yaml
@@ -18,7 +18,7 @@
 - name: install mtail programs
   copy:
     src: '{{ item }}'
-    dest: '/etc/mtail/{{ item | basename }}'
+    dest: /etc/mtail/{{ item | basename }}
     owner: root
     group: root
     mode: '0644'

--- a/mtail/tasks/main.yaml
+++ b/mtail/tasks/main.yaml
@@ -29,7 +29,7 @@
   service:
     name: mtail
     state: started
-    enabled: yes
+    enabled: true
 
 - name: install ferm configuration
   template:

--- a/mtail/tasks/main.yaml
+++ b/mtail/tasks/main.yaml
@@ -12,7 +12,7 @@
     dest: /etc/default/mtail
     owner: root
     group: root
-    mode: 0644
+    mode: '0644'
   notify: mtail__restart_mtail
 
 - name: install mtail programs
@@ -21,7 +21,7 @@
     dest: '/etc/mtail/{{ item | basename }}'
     owner: root
     group: root
-    mode: 0644
+    mode: '0644'
   notify: mtail__restart_mtail
   with_items: '{{ mtail__programs or [] }}'
 
@@ -37,6 +37,6 @@
     dest: /etc/ferm/ferm.d/mtail.conf
     owner: root
     group: root
-    mode: 0644
+    mode: '0644'
   notify: mtail__reload_ferm
   when: mtail__install_ferm_svc | bool

--- a/net/tasks/main.yaml
+++ b/net/tasks/main.yaml
@@ -9,7 +9,7 @@
 - name: gather facts about services
   service_facts:
   # Run normally even in check mode.
-  check_mode: no
+  check_mode: false
   when: ansible_service_mgr == 'systemd'
 
 - name: stop and disable conflicting services

--- a/net/tasks/main.yaml
+++ b/net/tasks/main.yaml
@@ -30,7 +30,7 @@
     dest: /etc/udev/rules.d/70-persistent-net.rules
     owner: root
     group: root
-    mode: 0644
+    mode: '0644'
   notify: net__restart_all
   when: net__use_udev_persistent_rules | bool
 
@@ -40,7 +40,7 @@
     dest: /etc/network/interfaces
     owner: root
     group: root
-    mode: 0644
+    mode: '0644'
   notify: net__reconfigure_network
   when: net__interfaces
 

--- a/prometheus-node-exporter/tasks/main.yaml
+++ b/prometheus-node-exporter/tasks/main.yaml
@@ -10,15 +10,15 @@
     (prometheus-node-exporter --version 2>&1 || echo "unknown version 0.0") |
     sed -n 's/.* version \([0-9.]\+[0-9]\).*/\1/p'
   register: node_exporter__version_check
-  changed_when: False
+  changed_when: false
   # Run normally even in check mode.
-  check_mode: no
+  check_mode: false
 
 - name: find installed version
   set_fact:
     node_exporter__version: '{{ node_exporter__version_check.stdout | d("0") }}'
   # Run normally even in check mode.
-  check_mode: no
+  check_mode: false
 
 - name: configure node_exporter
   template:
@@ -33,7 +33,7 @@
   service:
     name: prometheus-node-exporter
     state: started
-    enabled: yes
+    enabled: true
 
 - name: install ferm configuration
   template:

--- a/prometheus-node-exporter/tasks/main.yaml
+++ b/prometheus-node-exporter/tasks/main.yaml
@@ -26,7 +26,7 @@
     dest: /etc/default/prometheus-node-exporter
     owner: root
     group: root
-    mode: 0644
+    mode: '0644'
   notify: node_exporter__restart_node_exporter
 
 - name: start and enable service
@@ -41,6 +41,6 @@
     dest: /etc/ferm/ferm.d/prometheus-node-exporter.conf
     owner: root
     group: adm
-    mode: 0644
+    mode: '0644'
   notify: node_exporter__reload_ferm
   when: node_exporter__install_ferm_svc | bool

--- a/prometheus/tasks/main.yaml
+++ b/prometheus/tasks/main.yaml
@@ -38,9 +38,10 @@
   template:
     src: '{{ item }}'
     dest: /etc/prometheus/rules/{{
-      item | basename | regex_replace("\.j2$", "") }}
+      item | basename | regex_replace('\.j2$', '') }}
     # Avoid clashes with prometheus template language.
     variable_start_string: '{='
+    # yamllint disable-line rule:quoted-strings
     variable_end_string: '=}'
     owner: root
     group: root

--- a/prometheus/tasks/main.yaml
+++ b/prometheus/tasks/main.yaml
@@ -11,7 +11,7 @@
     dest: /etc/default/prometheus
     owner: root
     group: root
-    mode: 0644
+    mode: '0644'
   notify: prometheus__restart_prometheus
 
 - name: create rules directory
@@ -20,7 +20,7 @@
     state: directory
     owner: root
     group: root
-    mode: 0755
+    mode: '0755'
 
 - name: install rules files
   copy:
@@ -28,7 +28,7 @@
     dest: '/etc/prometheus/rules/{{ item | basename }}'
     owner: root
     group: root
-    mode: 0644
+    mode: '0644'
     validate: /usr/bin/promtool check rules %s
   notify: prometheus__reload_prometheus
   with_items: '{{ prometheus__rules }}'
@@ -44,7 +44,7 @@
     variable_end_string: '=}'
     owner: root
     group: root
-    mode: 0644
+    mode: '0644'
     validate: /usr/bin/promtool check rules %s
   notify: prometheus__reload_prometheus
   with_items: '{{ prometheus__rules }}'
@@ -56,7 +56,7 @@
     dest: /etc/prometheus/prometheus.yml
     owner: root
     group: root
-    mode: 0644
+    mode: '0644'
     validate: /usr/bin/promtool check config %s
   notify: prometheus__reload_prometheus
 
@@ -72,6 +72,6 @@
     dest: /etc/ferm/ferm.d/prometheus.conf
     owner: root
     group: adm
-    mode: 0644
+    mode: '0644'
   notify: prometheus__reload_ferm
   when: prometheus__install_ferm_svc | bool

--- a/prometheus/tasks/main.yaml
+++ b/prometheus/tasks/main.yaml
@@ -64,7 +64,7 @@
   service:
     name: prometheus
     state: started
-    enabled: yes
+    enabled: true
 
 - name: install ferm configuration
   template:

--- a/prometheus/tasks/main.yaml
+++ b/prometheus/tasks/main.yaml
@@ -25,7 +25,7 @@
 - name: install rules files
   copy:
     src: '{{ item }}'
-    dest: '/etc/prometheus/rules/{{ item | basename }}'
+    dest: /etc/prometheus/rules/{{ item | basename }}
     owner: root
     group: root
     mode: '0644'
@@ -37,8 +37,8 @@
 - name: install rules templates
   template:
     src: '{{ item }}'
-    dest: '/etc/prometheus/rules/{{
-      item | basename | regex_replace("\.j2$", "") }}'
+    dest: /etc/prometheus/rules/{{
+      item | basename | regex_replace("\.j2$", "") }}
     # Avoid clashes with prometheus template language.
     variable_start_string: '{='
     variable_end_string: '=}'

--- a/prometheus/vars/main.yaml
+++ b/prometheus/vars/main.yaml
@@ -6,12 +6,12 @@ __prom_scrape_config:
   scrape_interval: 5s
   scrape_timeout: 5s
   static_configs:
-  - targets: '{{ (prometheus__monitored_prometheus or []) | list }}'
+    - targets: '{{ (prometheus__monitored_prometheus or []) | list }}'
 
 __node_scrape_config:
   job_name: 'node'
   static_configs:
-  - targets: '{{ (prometheus__monitored_nodes or []) | list }}'
+    - targets: '{{ (prometheus__monitored_nodes or []) | list }}'
 
 __federated_scrape_config:
   job_name: 'federate'
@@ -20,12 +20,12 @@ __federated_scrape_config:
   params:
     'match[]': '{{ prometheus__federate_filter }}'
   static_configs:
-  - targets: '{{ (prometheus__federated_prometheus or []) | list }}'
+    - targets: '{{ (prometheus__federated_prometheus or []) | list }}'
 
 __alertmanager_scrape_config:
   job_name: 'alertmanager'
   static_configs:
-  - targets: '{{ (prometheus__alertmanagers or []) | list }}'
+    - targets: '{{ (prometheus__alertmanagers or []) | list }}'
 
 __all_scrape_configs: |
   {{

--- a/prometheus/vars/main.yaml
+++ b/prometheus/vars/main.yaml
@@ -2,28 +2,28 @@
 ---
 
 __prom_scrape_config:
-  job_name: 'prometheus'
+  job_name: prometheus
   scrape_interval: 5s
   scrape_timeout: 5s
   static_configs:
     - targets: '{{ (prometheus__monitored_prometheus or []) | list }}'
 
 __node_scrape_config:
-  job_name: 'node'
+  job_name: node
   static_configs:
     - targets: '{{ (prometheus__monitored_nodes or []) | list }}'
 
 __federated_scrape_config:
-  job_name: 'federate'
+  job_name: federate
   honor_labels: true
-  metrics_path: '/federate'
+  metrics_path: /federate
   params:
     'match[]': '{{ prometheus__federate_filter }}'
   static_configs:
     - targets: '{{ (prometheus__federated_prometheus or []) | list }}'
 
 __alertmanager_scrape_config:
-  job_name: 'alertmanager'
+  job_name: alertmanager
   static_configs:
     - targets: '{{ (prometheus__alertmanagers or []) | list }}'
 

--- a/simple-bind/defaults/main.yaml
+++ b/simple-bind/defaults/main.yaml
@@ -6,10 +6,10 @@ simple_bind__options:
   forwarders: []
   listen_on:
     - port: 53
-      match_list: ['any']
+      match_list: [any]
   listen_on_v6:
     - port: 53
-      match_list: ['any']
+      match_list: [any]
   extra_conf:
 #    - 'foo: bar'
 

--- a/simple-bind/tasks/main.yaml
+++ b/simple-bind/tasks/main.yaml
@@ -11,13 +11,13 @@
     - service:
         name: bind9
         state: started
-        enabled: yes
+        enabled: true
   rescue:
     # systemd unit name changed in Debian bullseye.
     - service:
         name: named
         state: started
-        enabled: yes
+        enabled: true
 
 - name: install configuration files
   template:

--- a/simple-bind/tasks/main.yaml
+++ b/simple-bind/tasks/main.yaml
@@ -25,7 +25,7 @@
     dest: '/etc/bind/{{ item }}'
     owner: root
     group: root
-    mode: 0644
+    mode: '0644'
   loop:
     - named.conf
     - named.conf.options
@@ -38,6 +38,6 @@
     dest: /etc/ferm/ferm.d/bind.conf
     owner: root
     group: adm
-    mode: 0644
+    mode: '0644'
   notify: simple_bind__reload_ferm
   when: simple_bind__install_ferm_svc | bool

--- a/simple-bind/tasks/main.yaml
+++ b/simple-bind/tasks/main.yaml
@@ -22,7 +22,7 @@
 - name: install configuration files
   template:
     src: '{{ item }}.j2'
-    dest: '/etc/bind/{{ item }}'
+    dest: /etc/bind/{{ item }}
     owner: root
     group: root
     mode: '0644'

--- a/simple-bind/tasks/main.yaml
+++ b/simple-bind/tasks/main.yaml
@@ -8,13 +8,15 @@
 
 - name: start and enable service
   block:
-    - service:
+    - name: start bind9
+      ansible.builtin.service:
         name: bind9
         state: started
         enabled: true
   rescue:
     # systemd unit name changed in Debian bullseye.
-    - service:
+    - name: start named
+      ansible.builtin.service:
         name: named
         state: started
         enabled: true

--- a/users/tasks/main.yaml
+++ b/users/tasks/main.yaml
@@ -35,12 +35,12 @@
       password: '{{ _user.password | d("*") }}'
       groups: '{{ _user.groups | default([]) | join(",") }}'
       append: '{{ _user.append | d() | bool }}'
-      home: '{{
-        _user.home | d("/" if _user.get("system") else "/home/" ~ _user.name) }}'
+      home: '{{ _user.home
+        | d("/" if _user.get("system") else "/home/" ~ _user.name) }}'
       create_home: '{{ _user.create_home | d(True) | bool }}'
       move_home: '{{ _user.move_home | d(not _user.get("system")) | bool }}'
-      shell: '{{
-        _user.shell | d("/bin/false" if _user.get("system") else "/bin/bash") }}'
+      shell: '{{ _user.shell
+        | d("/bin/false" if _user.get("system") else "/bin/bash") }}'
       generate_ssh_key: '{{ _user.generate_ssh_key | d() | bool }}'
       update_password: '{{
         "always" if users__force_update_password else (

--- a/users/tasks/main.yaml
+++ b/users/tasks/main.yaml
@@ -2,7 +2,7 @@
 ---
 - name: sanity check
   fail:
-    msg: 'Cannot remove the user running ansible ({{ ansible_user }})!'
+    msg: Cannot remove the user running ansible ({{ ansible_user }})!
   when: >-
     ansible_user is defined and ansible_user in (users__remove_users | d([]))
 

--- a/users/tasks/main.yaml
+++ b/users/tasks/main.yaml
@@ -35,12 +35,12 @@
       password: '{{ _user.password | d("*") }}'
       groups: '{{ _user.groups | default([]) | join(",") }}'
       append: '{{ _user.append | d() | bool }}'
-      home: '{{ _user.home
-        | d("/" if _user.get("system") else "/home/" ~ _user.name) }}'
+      home: '{{ _user.home |
+        d("/" if _user.get("system") else "/home/" ~ _user.name) }}'
       create_home: '{{ _user.create_home | d(True) | bool }}'
       move_home: '{{ _user.move_home | d(not _user.get("system")) | bool }}'
-      shell: '{{ _user.shell
-        | d("/bin/false" if _user.get("system") else "/bin/bash") }}'
+      shell: '{{ _user.shell |
+        d("/bin/false" if _user.get("system") else "/bin/bash") }}'
       generate_ssh_key: '{{ _user.generate_ssh_key | d() | bool }}'
       update_password: '{{
         "always" if users__force_update_password else (

--- a/users/tasks/user.yaml
+++ b/users/tasks/user.yaml
@@ -43,7 +43,8 @@
     owner: '{{ user.name }}'
     group: '{{ user.name }}'
     state: directory
-  with_filetree: '{{ users__home_dir_templates }}/{{ user.name }}'
+  with_community.general.filetree: '{{
+    users__home_dir_templates }}/{{ user.name }}'
   when: item.state == 'directory'
 
 - name: '[{{ user.name }}] set-up user home: normal files'
@@ -53,7 +54,8 @@
     mode: '{{ item.mode }}'
     owner: '{{ user.name }}'
     group: '{{ user.name }}'
-  with_filetree: '{{ users__home_dir_templates }}/{{ user.name }}'
+  with_community.general.filetree: '{{
+    users__home_dir_templates }}/{{ user.name }}'
   when: item.state == 'file' and not item.src.endswith('.j2')
 
 - name: '[{{ user.name }}] set-up user home: templates'
@@ -63,7 +65,8 @@
     mode: '{{ item.mode }}'
     owner: '{{ user.name }}'
     group: '{{ user.name }}'
-  with_filetree: '{{ users__home_dir_templates }}/{{ user.name }}'
+  with_community.general.filetree: '{{
+    users__home_dir_templates }}/{{ user.name }}'
   when: item.state == 'file' and item.src.endswith('.j2')
 
 - name: '[{{ user.name }}] set-up user home: symlinks'
@@ -76,5 +79,6 @@
     state: link
     force: true
     follow: false
-  with_filetree: '{{ users__home_dir_templates }}/{{ user.name }}'
+  with_community.general.filetree: '{{
+    users__home_dir_templates }}/{{ user.name }}'
   when: item.state == 'link'

--- a/users/tasks/user.yaml
+++ b/users/tasks/user.yaml
@@ -30,11 +30,11 @@
 - name: '[{{ user.name }}] set SSH authorized keys'
   authorized_key:
     user: '{{ user.name }}'
-    key: "{{
+    key: '{{
       user.authorized
       if user.authorized is string else
-      '\n'.join(user.authorized)
-      }}"
+      "\n".join(user.authorized)
+      }}'
     exclusive: true
 
 - name: '[{{ user.name }}] set-up user home: directories'

--- a/users/tasks/user.yaml
+++ b/users/tasks/user.yaml
@@ -30,9 +30,11 @@
 - name: '[{{ user.name }}] set SSH authorized keys'
   authorized_key:
     user: '{{ user.name }}'
-    key: '{{
-      user.authorized
-      if user.authorized is string else
+    key: |
+      {{
+        user.authorized if user.authorized is string else
+        '\n'.join(user.authorized)
+      }}
       "\n".join(user.authorized)
       }}'
     exclusive: true

--- a/users/tasks/user.yaml
+++ b/users/tasks/user.yaml
@@ -9,7 +9,8 @@
     name: '{{ user.name }}'
     comment: '{{ user.gecos }}'
     password: '{{ user.password }}'
-    groups: '{{ user.groups if user.groups is string else ",".join(user.groups) }}'
+    groups: '{{
+      user.groups if user.groups is string else ",".join(user.groups) }}'
     append: '{{ user.append }}'
     home: '{{ user.home }}'
     create_home: '{{ user.create_home }}'

--- a/users/tasks/user.yaml
+++ b/users/tasks/user.yaml
@@ -13,7 +13,7 @@
     append: '{{ user.append }}'
     home: '{{ user.home }}'
     create_home: '{{ user.create_home }}'
-    move_home:  '{{ user.move_home }}'
+    move_home: '{{ user.move_home }}'
     shell: '{{ user.shell }}'
     generate_ssh_key: '{{ user.generate_ssh_key }}'
     update_password: '{{ user.update_password }}'


### PR DESCRIPTION
- 0d1832be660c5bc6b7a942a233ae17f4d38a9358 Use FQDN for with_filetree (community.general)
- 1a8313a409d43c37c230f16d22daf29f3b6383ea Fix yaml whitespace lints (colons, comments, indentation)
- 00577cb6d4ad181d5c5eac6f5eb7cc57ac9ba329 Fix lint: yaml[truthy]
- 92de9c3c0af47a7270b8b0b1af5267c38d9c1549 Fix lint: yaml[octal-values]
- 580b9ddafe01b159bfa43796327d8bd36433a191 Fix lint: yaml[line-length], add yamllint conf
- 19a501c76495e219a3e8012487f08467a7492095 Fix lint: yaml[quoted-strings]
- a8537e5267ae4beb09ae27c8bee52b264742da74 ansible-lint with moderate profile and some skipped rules (passing)
- 8d0793226dc18cb5d49350abf9926d206ac6779a ansible-lint workflow

-----