### PR TITLE
Add glauth role

### DIFF
--- a/roles/glauth/defaults/main.yaml
+++ b/roles/glauth/defaults/main.yaml
@@ -1,0 +1,64 @@
+# vim:ts=2:sw=2:et:ai:sts=2
+---
+glauth__config_file: /etc/glauth/glauth.toml
+glauth__install_ferm_svc: false  # Not implemented yet.
+
+# General options
+glauth__enable_debug: false
+glauth__log_to_syslog: false
+glauth__structured_log: false
+
+# Services that can be enabled
+glauth__service_ldap:
+  enabled: false
+
+glauth__service_ldaps:
+  enabled: false
+
+glauth__service_api:
+  enabled: false
+
+# Other options
+glauth__config_tracing:
+  enabled: false
+
+glauth__config_behaviors:
+  LimitFailedBinds: false
+  IgnoreCapabilities: false
+
+# glauth__config_backends: List of enabled backends. Each of them should
+# have, at least, `datastore` and `baseDN`.
+glauth__config_backends: []
+
+# glauth__config_datastore_groups: List of groups, passed to the config backend
+# as-is. Elements should have, at least, `name` and `gidnumber`. Example:
+#
+# glauth__config_datastore_groups:
+#   - name: people
+#     gidnumber: 1000001
+#   - name: svcaccts
+#     gidnumber: 1000002
+glauth__config_datastore_groups: []
+
+# glauth__config_datastore_users: List of users. Most fields are supported,
+# except `passsha256` and `passappsha256` (see [1] and [2] for the list of
+# fields).
+#
+# Also, for convenience, `passbcrypt` need not be hex-encoded.
+# yamllint disable rule:line-length
+#
+#   [1] https://github.com/glauth/glauth/blob/a5ecc26e/v2/sample-simple.cfg#L84-L114
+#   [2] https://github.com/glauth/glauth/blob/a5ecc26e/v2/pkg/config/config.go#L86-L108
+#
+# yamllint enable rule:line-length
+# Example:
+#
+# glauth__config_datastore_users:
+#   - name: grafana
+#     uidnumber: 1200001
+#     primarygroup: 1000002
+#     passbcrypt: '$2b$...'
+#     capabilities:
+#       - action: search
+#         object: '*'
+glauth__config_datastore_users: []

--- a/roles/glauth/filter_plugins/filters.py
+++ b/roles/glauth/filter_plugins/filters.py
@@ -1,0 +1,16 @@
+# https://www.iops.tech/blog/generate-toml-using-ansible-template/
+
+import json
+import toml
+
+
+class FilterModule:
+
+    def filters(self):
+        return {
+            "to_toml": self.to_toml,
+        }
+
+    def to_toml(self, variable):
+        serialized_json = json.dumps(dict(variable))
+        return toml.dumps(json.loads(serialized_json))

--- a/roles/glauth/handlers/main.yaml
+++ b/roles/glauth/handlers/main.yaml
@@ -1,0 +1,6 @@
+# vim:ts=2:sw=2:et:ai:sts=2
+---
+- name: _tina_restart_glauth
+  ansible.builtin.service:
+    name: glauth
+    state: restarted

--- a/roles/glauth/tasks/main.yaml
+++ b/roles/glauth/tasks/main.yaml
@@ -1,0 +1,28 @@
+# vim:ts=2:sw=2:et:ai:sts=2
+---
+- name: Install package
+  ansible.builtin.package:
+    name: glauth
+    state: present
+
+- name: Create user
+  ansible.builtin.user:
+    name: glauth
+    state: present
+    system: true
+
+- name: Configure service
+  ansible.builtin.template:
+    src: glauth.toml.j2
+    dest: '{{ glauth__config_file }}'
+    owner: root
+    group: glauth
+    mode: '0640'
+    validate: /usr/bin/glauth -c %s --check-config
+  notify: _tina_restart_glauth
+
+- name: Start and enable service
+  ansible.builtin.service:
+    name: glauth
+    state: started
+    enabled: true

--- a/roles/glauth/templates/glauth.toml.j2
+++ b/roles/glauth/templates/glauth.toml.j2
@@ -1,0 +1,6 @@
+# {{ ansible_managed }}
+
+{{ _glauth_toplevel | to_toml }}
+{{ _glauth_services | to_toml }}
+{{ _glauth_configs | to_toml }}
+{{ _glauth_datastore | to_toml }}

--- a/roles/glauth/vars/main.yaml
+++ b/roles/glauth/vars/main.yaml
@@ -1,0 +1,41 @@
+# vim:ts=2:sw=2:et:ai:sts=2
+---
+# TODO: validation.
+_glauth_toplevel:
+  debug: '{{ glauth__enable_debug | bool }}'
+  syslog: '{{ glauth__log_to_syslog | bool }}'
+  structuredlog: '{{ glauth__structured_log | bool }}'
+
+_glauth_services:
+  api: '{{ glauth__service_api }}'
+  ldap: '{{ glauth__service_ldap }}'
+  ldaps: '{{ glauth__service_ldaps }}'
+
+_glauth_configs:
+  tracing: '{{ glauth__config_tracing }}'
+  backends: '{{ glauth__config_backends }}'
+  behaviors: '{{ glauth__config_behaviors }}'
+
+_glauth_datastore:
+  groups: '{{ glauth__config_datastore_groups }}'
+  # users filter:
+  #   - drop passsha256/passappsha256
+  #   - optionally hexlify passbcrypt
+  users: |
+      {% filter ansible.builtin.from_yaml %}
+      {% if glauth__config_datastore_users %}
+      {% set users = glauth__config_datastore_users | ansible.utils.remove_keys(
+             matching_parameter='regex', target='(?i)pass(app)?sha256$') %}
+      {% for user in users %}
+      {% set pass = user.get('passbcrypt') or '' %}
+      {% set pass = (pass.encode('ascii').hex() if pass.startswith('$')
+                     else pass) %}
+      - {{ user |
+           combine(dict(passbcrypt=pass)) |
+           ansible.builtin.to_yaml(default_flow_style=True)
+      }}
+      {% endfor %}
+      {% else %}
+      []
+      {% endif %}
+      {% endfilter %}


### PR DESCRIPTION
I'm requesting comments on the following two "deviations":

1.  I'm rejecting, at role level, the use of SHA256 passwords, allowing only bcrypt. Sounds sensible?

    (This is implemented with `ansible.utils.remove_keys` in vars/main.yml.)

4.  I'd like for LDAP passwords in ASSEKURANSA/sysadmin to be stored as plain bcrypt, rather than the hexlified versions that glauth requires (which are much longer).

    I find this ergonomic, but the current implementation is fugly /o\  (see FIXME in tasks/main.yml)