### PR TITLE
Really fix `user.authorized` join

### DIFF
--- a/users/tasks/user.yaml
+++ b/users/tasks/user.yaml
@@ -30,11 +30,14 @@
 - name: '[{{ user.name }}] set SSH authorized keys'
   ansible.posix.authorized_key:
     user: '{{ user.name }}'
-    key: |
-      {{
-        user.authorized if user.authorized is string else
-        '\n'.join(user.authorized)
-      }}
+    # Important: double quotes scalar is needed here so that '\n'.join() uses
+    # actual newlines, and not literal r'\n'.
+    # yamllint disable-line rule:quoted-strings
+    key: "{{
+      user.authorized
+      if user.authorized is string else
+      '\n'.join(user.authorized)
+      }}"
     exclusive: true
 
 - name: '[{{ user.name }}] set-up user home: directories'


### PR DESCRIPTION
This commits reverts the `user.authorized` join expression right before 19a501c ("Fix lint: yaml[quoted-strings]"), and adds a yamllint override.

For `'\n'.join()` to work properly (using newline characters, and not literal `r'\n'`), the only option is a YAML double-quote scalar.