### PR TITLE
Add molecule test for SSH authorized keys

### DIFF
--- a/.github/workflows/molecule.yaml
+++ b/.github/workflows/molecule.yaml
@@ -1,0 +1,26 @@
+---
+name: molecule
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - force_ci/molecule/**  # For development/debugging of the workflow.
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  molecule:
+    name: Molecule tests
+    runs-on: ubuntu-latest
+    steps:
+      - id: checkout
+        uses: actions/checkout@v4
+        with:
+          path: ${{ github.repository }}
+
+      - name: Run molecule
+        uses: gofrolist/molecule-action@v2

--- a/.github/workflows/molecule.yaml
+++ b/.github/workflows/molecule.yaml
@@ -24,3 +24,5 @@ jobs:
 
       - name: Run molecule
         uses: gofrolist/molecule-action@v2
+        with:
+          molecule_options: --verbose

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -1,0 +1,7 @@
+---
+- name: Molecule converge
+  hosts: all
+  tasks:
+    - name: Apply users role fixtures
+      ansible.builtin.include_role:
+        name: test_users

--- a/molecule/default/create.yml
+++ b/molecule/default/create.yml
@@ -1,0 +1,12 @@
+---
+- name: Create molecule hosts
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Create container
+      loop: '{{ molecule_yml.platforms }}'
+      community.docker.docker_container:
+        name: '{{ item.name }}'
+        image: '{{ item.image }}'
+        state: started
+        command: sleep 1d  # TODO: run systemd

--- a/molecule/default/destroy.yml
+++ b/molecule/default/destroy.yml
@@ -1,0 +1,11 @@
+---
+- name: Destroy molecule containers
+  hosts: all  # FIXME: create and use molecule group
+  gather_facts: false
+  tasks:
+    - name: Stop and remove container
+      delegate_to: localhost
+      community.docker.docker_container:
+        name: '{{ inventory_hostname }}'
+        state: absent
+        auto_remove: true

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,0 +1,13 @@
+---
+platforms:
+  - name: bookworm-tinapm
+    image: geerlingguy/docker-debian12-ansible
+
+provisioner:
+  name: ansible
+  env:
+    ANSIBLE_ROLES_PATH: ../..
+  inventory:
+    group_vars:
+      all:
+        ansible_connection: community.docker.docker

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -7,6 +7,10 @@ provisioner:
   name: ansible
   env:
     ANSIBLE_ROLES_PATH: ../..
+  config_options:
+    defaults:
+      stdout_callback: debug
+      stderr_callback: debug
   inventory:
     group_vars:
       all:

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -1,0 +1,8 @@
+---
+collections:
+  - name: community.docker
+    source: https://galaxy.ansible.com
+    version: '>=3.10.2'
+  # TODO(dato): consolidate role dependencies in one top-level requirements file
+  - name: ansible.posix
+  - name: community.general

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -1,8 +1,0 @@
----
-collections:
-  - name: community.docker
-    source: https://galaxy.ansible.com
-    version: '>=3.10.2'
-  # TODO(dato): consolidate role dependencies in one top-level requirements file
-  - name: ansible.posix
-  - name: community.general

--- a/molecule/default/roles/test_users/tasks/main.yml
+++ b/molecule/default/roles/test_users/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- name: Run users role
+  ansible.builtin.include_role:
+    name: users

--- a/molecule/default/roles/test_users/tasks/verify.yml
+++ b/molecule/default/roles/test_users/tasks/verify.yml
@@ -1,0 +1,32 @@
+---
+- name: Detect .ssh dir
+  ansible.builtin.stat:
+    path: '{{ _authorized_keys | dirname }}'
+  register: ssh_dir
+
+- name: Detect authorized_keys file
+  ansible.builtin.stat:
+    path: '{{ _authorized_keys }}'
+  register: authorized_file
+
+- name: Detect authorized SSH keys
+  ansible.builtin.lineinfile:
+    path: '{{ _authorized_keys }}'
+    line: '{{ item }}'
+    state: absent  # Allows asserting on `found`, below.
+  check_mode: true
+  changed_when: false
+  loop:
+    - ssh-ed25519 XXX 1
+    - ssh-ed25519 YYY 2
+  register: ssh_keys
+
+- name: Assert SSH authorization is correct
+  ansible.builtin.assert:
+    that:
+      - ssh_dir.stat.mode == '0700'
+      - ssh_dir.stat.pw_name == 'sshtest'
+      - authorized_file.stat.exists
+      - authorized_file.stat.isreg
+      - ssh_keys.results[0].found
+      - ssh_keys.results[1].found

--- a/molecule/default/roles/test_users/vars/main.yml
+++ b/molecule/default/roles/test_users/vars/main.yml
@@ -1,0 +1,9 @@
+---
+users__create_users:  # noqa: var-naming[no-role-prefix]
+  - name: sshtest
+    authorized:
+      - ssh-ed25519 XXX 1
+      - ssh-ed25519 YYY 2
+
+_authorized_keys: >-  # noqa: var-naming[no-role-prefix]
+  /home/sshtest/.ssh/authorized_keys

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -1,0 +1,8 @@
+---
+- name: Molecule verify
+  hosts: all
+  tasks:
+    - name: Verify users role
+      ansible.builtin.include_role:
+        name: test_users
+        tasks_from: verify.yml

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,6 @@
+---
+collections:
+  - name: ansible.posix
+  - name: community.general
+  - name: community.docker
+    version: '>=3.10.2'

--- a/users/meta/requirements.yml
+++ b/users/meta/requirements.yml
@@ -1,4 +1,0 @@
----
-collections:
-  - name: ansible.posix
-    source: https://galaxy.ansible.com

--- a/users/tasks/user.yaml
+++ b/users/tasks/user.yaml
@@ -30,11 +30,14 @@
 - name: '[{{ user.name }}] set SSH authorized keys'
   ansible.posix.authorized_key:
     user: '{{ user.name }}'
-    key: |
-      {{
-        user.authorized if user.authorized is string else
-        '\n'.join(user.authorized)
-      }}
+    # Important: double quotes scalar is needed here so that '\n'.join() uses
+    # actual newlines, and not literal r'\n'.
+    # yamllint disable-line rule:quoted-strings
+    key: "{{
+      user.authorized
+      if user.authorized is string else
+      '\n'.join(user.authorized)
+      }}"
     exclusive: true
 
 - name: '[{{ user.name }}] set-up user home: directories'


### PR DESCRIPTION
Molecule workflow is failing here because the authorized join is broken in main: but see how it passes in #16!

Also, I had to consolidate dependencies in a top-level requirements.yml, it was the only way I could make ansible-lint happy.